### PR TITLE
add fix NO-SMEUP variables (xmlini and pingPeriod)

### DIFF
--- a/smartkitConfBase.sh
+++ b/smartkitConfBase.sh
@@ -240,8 +240,18 @@ while [ $V -le $[$MX+1] ]; do
             ## l'ambiente va impostato solo se Smart kit 'Sme.UP'
                 sed -i "s/#env=/env=/" $fileconfig
             else
-            ## la riga con env= va commentata
+                ## Siamo nel caso di NON-SMEUP
+                ## la riga con env= va commentata
                 sed -i "s/env=/#env=/" $fileconfig
+
+                ## La riga con xmlini va decommentata e impostata su DEFAULT
+                ## per prendere xml di default
+                sed -i "/#xmlini=.*/a xmlini=DEFAULT" $fileconfig
+
+                ## Il ping deve essere disattivato
+                ## Lasciati entrambi per mantenere conpatibilità
+                sed -i "s/pingPeriod=100/#pingPeriod=100/" $fileconfig
+                sed -i "s/#pingPeriod=-1/pingPeriod=-1/" $fileconfig
             fi
             X=1
             while [ $X -le $MX ] 


### PR DESCRIPTION
C'erano due cose non fatte quando il tipo di installazione è NO-SMEUP:
 - il pingPeriod deve passare da 100 a -1
 - il file xmlini deve essere decommentato e riportare la dicitura DEFAULT
 
 Si è deciso di mantenere entrambe le voci sia di env che #env  e pingPeriod=100 e pingPeriodo=-1 per mantenere compatibilità con quanto distribuito.
